### PR TITLE
remove '--all' option from list releases command

### DIFF
--- a/pkg/helm/release.go
+++ b/pkg/helm/release.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (cli *HelmCLI) ListReleases(ctx context.Context, namespace string) (releases []string, err error) {
-	out, err := cli.RunCmd(ctx, "list", "--namespace", namespace, "--all", "--output", "json")
+	out, err := cli.RunCmd(ctx, "list", "--namespace", namespace, "--output", "json")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
With helm 4, I get the following error with some commands:

> Error: unknown flag: --all

Removing it seems to fix it -- I hope I'm not missing something obvious with this change. Perhaps checking the helm version and adding/removing the `--all` flag based on that would be a better strategy?